### PR TITLE
Block drops fix

### DIFF
--- a/src/main/resources/data/minecraft/tags/block/mineable/axe.json
+++ b/src/main/resources/data/minecraft/tags/block/mineable/axe.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "simulatedextra:centered_wheel_mount"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "simulatedextra:centered_wheel_mount"
+  ]
+}

--- a/src/main/resources/data/simulatedextra/loot_table/blocks/centered_wheel_mount.json
+++ b/src/main/resources/data/simulatedextra/loot_table/blocks/centered_wheel_mount.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "simulatedextra:centered_wheel_mount"
+        }
+      ],
+      "rolls": 1
+    }
+  ],
+  "random_sequence": "simulatedextra:blocks/centered_wheel_mount"
+}


### PR DESCRIPTION
Adds a block drop loot table, and makes the mount mineable with both pickaxe and axe.
I haven't built this fork, but I have used these files in a datapack and they seem to work.